### PR TITLE
Fix wrong regular expression in sshd config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ WORKDIR /root
 
 RUN mkdir -p /var/log/supervisor && \
     mkdir -p /var/run/sshd && \
-    sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     echo 'root:root' | chpasswd && \
     rm -rf .ssh && \
     rm -rf .profile && \


### PR DESCRIPTION
In this commit, the Dockerfile was changed to fix wrong regular expression to allow ssh with `root:root`.

NOTE: This is a security issue and I will open a different `PR` to remove this block of code.

If we want to enter inside the container We should use:
```
docker exec -it <CONTAINER_ID> bash
````

What do you think about this solution?

Thoughts? 🤔  