### PR TITLE
Use debian:stretch-slim instead of ubuntu.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM debian:stretch-slim
 MAINTAINER Phil Hawthorne <me@philhawthorne.com>
 
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The ubuntu image is double the size of `debian:stretch-slim`