### PR TITLE
Remove SSH from supervisor

### DIFF
--- a/supervisord/supervisord.conf
+++ b/supervisord/supervisord.conf
@@ -1,10 +1,6 @@
 [supervisord]
 nodaemon = true
 
-[program:sshd]
-priority = 1
-command = /usr/sbin/sshd -D
-
 [program:influxdb]
 priority = 2
 command = bash -c "/etc/init.d/influxdb start && sleep 5"


### PR DESCRIPTION
As we no longer expose an SSH server, we should remove it from the supervisor config to reduce errors