### PR TITLE
Set SameSite to Lax so Grafana login can work

### DIFF
--- a/grafana/grafana.ini
+++ b/grafana/grafana.ini
@@ -136,8 +136,8 @@ admin_password = root
 # Enable iFrame embedding
 allow_embedding = true
 
-# Set cookie SameSite to None so that embedding is supported
-cookie_samesite = none
+# Set cookie SameSite to Lax so that embedding should work
+cookie_samesite = Lax
 
 # disable gravatar profile images
 ;disable_gravatar = false


### PR DESCRIPTION
Related to #41 the new version of Grafana requires a secure cookie
attribute.

Setting this to Lax should hopefully allow Grafana to remain being
embedded in Home Assistant, and allow regular login.

Fixes #44