### PR TITLE
updates to latest versions for security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,12 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LANG C.UTF-8
 
 # Default versions
-ENV INFLUXDB_VERSION=1.8.3
-ENV CHRONOGRAF_VERSION=1.8.7
-ENV GRAFANA_VERSION=7.2.1
+ENV INFLUXDB_VERSION=1.8.10
+ENV CHRONOGRAF_VERSION=1.9.4
+ENV GRAFANA_VERSION=7.5.16
 
 # Grafana database type
 ENV GF_DATABASE_TYPE=sqlite3
-
-# Fix bad proxy issue
-COPY system/99fixbadproxy /etc/apt/apt.conf.d/99fixbadproxy
 
 WORKDIR /root
 
@@ -42,8 +39,6 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
         supervisor \
         wget \
         gnupg \
-    && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
-    && apt-get install -y nodejs \
     && mkdir -p /var/log/supervisor \
     && rm -rf .profile \
     # Install InfluxDB

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ The main purpose of this image is to be used to show data from a [Home Assistant
 
 | Description  | Value   |
 |--------------|---------|
-| InfluxDB     | 1.8.3   |
-| ChronoGraf   | 1.8.7   |
-| Grafana      | 7.2.1   |
+| InfluxDB     | 1.8.10  |
+| ChronoGraf   | 1.9.4   |
+| Grafana      | 7.5.16  |
 
 ## Quick Start
 


### PR DESCRIPTION
updating influxdb to last/latest 1.x and grafana to last/latest 7.x
tested and working locally

note: 
* removed the fixbadproxy thing which did not appear to be a general issue
* removed the nodejs-10 install, as it is 1. past EOL, and 2. does not seem to be a requirement for influxdb, chronograf, or grafana